### PR TITLE
Changing footer links to hight contrast same as footer text and underline decoration for anchor hover and focus states

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -122,14 +122,11 @@ a {
   -ms-transition: text-shadow 0.5s ease;
 }
 
-#main_content a:hover {
-  color: #0069ba;
-  text-shadow: #0090ff 0px 0px 2px;
-}
+a:hover, a:focus {text-decoration: underline;}
 
-footer a:hover {
-  color: #43adff;
-  text-shadow: #0090ff 0px 0px 2px;
+footer a {
+  color: #F2F2F2;
+  text-decoration: underline;
 }
 
 em {


### PR DESCRIPTION
...erline for anchor focus hover states

Links with lower color contrast are hard to distinguish and links were showing blurred shadow on hover which is hard to read and click. Changing this to underline decoration for hover and focus
