### PR TITLE
Add hover effect with transition to `#forkme_banner`

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -281,6 +281,16 @@ Full-Width Styles
   box-shadow: 0 0 10px rgba(0,0,0,.5);
   border-bottom-left-radius: 2px;
   border-bottom-right-radius: 2px;
+  
+  transition: background-color 0.5s ease;
+  -webkit-transition: background-color 0.5s ease;
+  -moz-transition: background-color 0.5s ease;
+  -o-transition: background-color 0.5s ease;
+  -ms-transition: background-color 0.5s ease;
+}
+
+#forkme_banner:hover, #forkme_banner:focus {
+  background-color: #0069BA
 }
 
 #header_wrap {

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -276,7 +276,7 @@ Full-Width Styles
   z-index: 10;
   padding: 10px 50px 10px 10px;
   color: #fff;
-  background: url('../images/blacktocat.png') #0090ff no-repeat 95% 50%;
+  background: url('../images/blacktocat.png') #0069BA no-repeat 95% 50%;
   font-weight: 700;
   box-shadow: 0 0 10px rgba(0,0,0,.5);
   border-bottom-left-radius: 2px;
@@ -290,7 +290,7 @@ Full-Width Styles
 }
 
 #forkme_banner:hover, #forkme_banner:focus {
-  background-color: #0069BA
+  background-color: #0090FF
 }
 
 #header_wrap {


### PR DESCRIPTION
Makes the "View on GitHub" banner look a bit fancier when you hover over it. To see the result in action, see:
- http://static.iqandreas.com/

The colors used were basically picked arbitrarily from "what looked good" in an online color-picker, and are open to suggestions _(Damn it, Jim, I'm a developer, not a designer!)_.
