### PR TITLE
Stop code blocks "hanging over the edge"

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -170,22 +170,20 @@ pre, code {
   font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
   font-size: 14px;
 
+  box-shadow: 0 0 10px rgba(0,0,0,.1);
   border-radius: 2px;
   -moz-border-radius: 2px;
   -webkit-border-radius: 2px;
 }
 
 pre {
-  width: 100%;
   padding: 10px;
-  box-shadow: 0 0 10px rgba(0,0,0,.1);
   overflow: auto;
 }
 
 code {
   padding: 3px;
   margin: 0 3px;
-  box-shadow: 0 0 10px rgba(0,0,0,.1);
 }
 
 pre code {


### PR DESCRIPTION
It may not be clear in your examples, but `code` and `pre` blocks have a tendency to "poke out over the edge" past the page's max-width. This problem becomes even more clear if your text is justified, or if your page has borders:

![slate-code-blocks-too-wide](https://f.cloud.github.com/assets/449027/1622679/84b7ac32-56a9-11e3-9844-8a0db4389c4f.png)

The first commit fixes this problem with `box-sizing: border-box`. It won't work for IE7, but the worst that happens for them is it just keeps looking like it does now (and are we still supposed to support IE7 anyway?).

The pull request also contains a second commit which removes/merges two lines of duplicate code in that same area. If you prefer, I can remove this second commit from the pull request.
