### PR TITLE
Fix image overflow when media screen is too small

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -308,6 +308,12 @@ header {
 Small Device Styles
 *******************************************************************************/
 
+@media screen and (max-width: 992px) {
+  img {
+    max-width: 100%;
+  }
+}
+
 @media screen and (max-width: 480px) {
   body {
     font-size: 13px;
@@ -366,9 +372,5 @@ Small Device Styles
     min-width: 320px;
     max-width: 480px;
     font-size: 11px;
-  }
-
-  img {
-    ma
   }
 }


### PR DESCRIPTION
The awesome octocat image is lit' bit "rare" (in size)!

When the screen width is too small (e.g. view in mobile device), the image will overflow and makes the page scrollable. This should not happen.

To fix this, I make the img becomes max-width: 100%; when media screen is below 992px. 992px is Medium Devices Desktops in Bootstrap. Hopefully only 1 line of css for this break-point is not too rare.

p.s. Put the line in max-width: 480px is not enough. And, for medium devices, fixing a certain width for images may be too small. That's why I make it 100%.

> FYI, I also make a pull request in [pages-themes/slate][1].

[1]: https://github.com/pages-themes/slate/pull/3