### PR TITLE
Reduce min-width for iPhone SE

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -328,7 +328,7 @@ Small Device Styles
   }
 
   .inner {
-    min-width: 320px;
+    min-width: 300px;
     max-width: 480px;
   }
 
@@ -369,7 +369,7 @@ Small Device Styles
   }
 
   code, pre {
-    min-width: 320px;
+    min-width: 300px;
     max-width: 480px;
     font-size: 11px;
   }


### PR DESCRIPTION
Steps to reproduce:
1. Load http://jasoncostello.github.io/slate/ in Safari
2. Enable Responsive Design Mode
3. Select iPhone SE (add device if necessary)
4. Notice you can scroll horizontally to the right, leaving a black bar on the right and text cut on the left.